### PR TITLE
Fixed bug so ichoropleth can handle repetition in data

### DIFF
--- a/R/Datamaps.R
+++ b/R/Datamaps.R
@@ -46,7 +46,7 @@ ichoropleth <- function(x, data, pal = "Blues", ncuts = 5, animate = NULL, play 
   data = transform(data, 
     fillKey = cut(
       fml$left, 
-      quantile(fml$left, seq(0, 1, 1/ncuts)),
+      unique(quantile(fml$left, seq(0, 1, 1/ncuts))),
       ordered_result = TRUE
     )
   )


### PR DESCRIPTION
Fixed a bug where ichoropleth would crash if run on data with more than one instance of a value in it, e.g. 1,1,2,3,4,5,6