### PR TITLE
add rjson to imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Imports:
     whisker,
     yaml,
     RColorBrewer,
-    rCharts
+    rCharts,
+    rjson
 Collate:
   Crosslet.R
   Datamaps.R


### PR DESCRIPTION
in Crosslet.R, you use 
`chartParams = rjson::toJSON(params[names(params) != 'dimensions'])`

when installing and running the demo I received the following:

```
> library(rMaps)
> crosslet(
+   x = "country", 
+   y = c("web_index", "universal_access", "impact_empowerment", "freedom_openness"),
+   data = web_index
+ )
Error in loadNamespace(name) : there is no package called ‘rjson’
```

Adding rjson to the DESCRIPTION should ensure it is installed as a dependency. 
